### PR TITLE
SystemD service template for gz-beat-shipper

### DIFF
--- a/cmd/shipper/main.go
+++ b/cmd/shipper/main.go
@@ -1,8 +1,16 @@
 package main
 
-import "log"
+import (
+	"log"
+	"time"
+)
+
+const SecondsForRecheck = 60
 
 func main() {
-    log.SetFlags(log.LstdFlags | log.Lshortfile)
-    log.Print("Testing :)")
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	for {
+		log.Print("Testing :)")
+		time.Sleep(time.Second * SecondsForRecheck)
+	}
 }

--- a/etc/systemd/system/gz-beat-shipper
+++ b/etc/systemd/system/gz-beat-shipper
@@ -1,0 +1,17 @@
+[Unit]
+Description=GNU ZIP Beat Shipper Service
+Documentation=https://github.com/RedHatCRE/gz-beat-shipper/blob/main/README.md
+After=network.target
+
+[Service]
+WorkingDirectory=/etc/gz-beat-shipper
+Type=simple
+ExecStart=/usr/sbin/gz-beat-shipper
+Restart=on-failure
+RestartSec=10
+# TODO: Do we want to keep the logs in syslog?
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=gz-beat-shipper
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Just a basic service template that will be adapted to the binary once we have it

e.g for now:

```
$ systemctl status gz-beat-shipper
● gz-beat-shipper.service - GNU ZIP Beat Shipper Service
     Loaded: loaded (/etc/systemd/system/gz-beat-shipper.service; enabled; vendor preset: enabled)
     Active: active (running) since Thu 2022-10-06 17:09:43 CEST; 5s ago
       Docs: https://github.com/RedHatCRE/gz-beat-shipper/blob/main/README.md
   Main PID: 10159 (gz-beat-shipper)
      Tasks: 5 (limit: 38094)
     Memory: 808.0K
        CPU: 5ms
     CGroup: /system.slice/gz-beat-shipper.service
             └─10159 /usr/sbin/gz-beat-shipper

oct 06 17:09:43 afuscoar systemd[1]: Started GNU ZIP Beat Shipper Service.
oct 06 17:09:43 afuscoar gz-beat-shipper[10159]: 2022/10/06 17:09:43 main.go:13: Testing :)
```