### PR TITLE
Change structure of the event for correct processing in logstash

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ An example is located in the root of the project. We should add the following fi
 - `path` array of paths that will be exploded using `GLOB`
 - `registry`: the name of the file where we'll store the processed files.
 - `recheck` time of recheck (re-process) if there are new pending files to send
+- `logsource` very useful in logstash to handle conditions based on the name of the source
 
 ## Usage:
 

--- a/beatshipper-conf.yml
+++ b/beatshipper-conf.yml
@@ -9,3 +9,4 @@ path:
 registry: "shipper_registry.json"
 # time of recheck (re-process) if there are new pending files to send
 recheck: 5s
+log_source: 'gzip_files'

--- a/configs/config.go
+++ b/configs/config.go
@@ -9,11 +9,12 @@ import (
 )
 
 type Configuration struct {
-	Host     string   `yaml:"host"`
-	Port     string   `yaml:"port"`
-	Paths    []string `yaml:"path"`
-	Registry string   `yaml:"registry"`
-	Recheck  string   `yaml:"recheck"`
+	Host      string   `yaml:"host"`
+	Port      string   `yaml:"port"`
+	Paths     []string `yaml:"path"`
+	Registry  string   `yaml:"registry"`
+	Recheck   string   `yaml:"recheck"`
+	LogSource string   `yaml:"logsource"`
 }
 
 func (c *Configuration) GetConfiguration() *Configuration {


### PR DESCRIPTION
- Change the way to create the events for being sent to logstash:
    - We had a simple structure. In this way it wasn’t possible to send the required nested fields to logstash. Now we can process the data using `[host][name]` and `[log][file][path]` in the right way. The data type used for nested fields - required - in the external module `go-lumber` is the following one: `map[string]interface{}`
- Added time of execution of the whole `shipper`.
- Added `logsource` field to the configuration.

--

Result of one event sent to logstash:

```
{
    "log" => {
        "file" => {
            "path" => [
                [ 0] "",
                [ 1] "jenkinst-test",
                [ 2] "jenkins-logs",
                [ 3] "rcj",
                [ 4] "test",
                [ 5] "sub-test",
                [ 6] "sub-sub-test999",
                [ 7] "var",
                [ 8] "log",
                [ 9] "extra2",
                [10] "rpm-list.txt.gz"
            ]
        }
    },
    "host" => {
        "name" => "afuscoar"
    },
     "type" => "beatshipper",
     "message" => "package1.rpm\npackage2.rpm\npackage3.rpm\n",
     "tags" => [
        [0] "beats_input_codec_plain_applied"
    ],
     "job_name" => "sub-test",
    "log_source" => "gzip_files",
    "@version" => "1",
    "@timestamp" => 2022-12-01T18:24:44.288Z,
}
```