### PR TITLE
Restructuring project

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,35 @@ An example is located in the root of the project. We should add the following fi
 - `recheck` time of recheck (re-process) if there are new pending files to send
 - `logsource` very useful in logstash to handle conditions based on the name of the source
 
+# Configuration through SystemD
+
+We have created two SystemD files:
+
+- `service` file: it specifies the binary that will execute the service
+- `timer` file: we are gonna execute the service as timer.
+
+By default the timer will launch the service in one shoot type every 30 minutes (`*:0/30`). If we wanna change the time we should change the `OnCalendar` directime in the `timer` file.
+
+These files are being coppied to the following directory `/lib/systemd/system/` if we install the generated RPM package.
+
+We can enable and start the `timer` with the following commands:
+
+```
+$ systemctl enable beatshipper.timer
+$ systemctl start beatshipper.timer
+```
+
+We can check if the timer has been activated:
+
+```
+$ systemctl list-timers | grep beatshipper -B1
+NEXT                        LEFT          LAST                        PASSED       UNIT                           ACTIVATES
+Mon 2022-12-26 16:00:00 CET 27min left    Mon 2022-12-26 15:30:32 CET 2min 12s ago beatshipper.timer              beatshipper.service
+
+$ journalctl -u beatshipper.timer
+dic 26 15:30:32 user systemd[1]: Started Beatshipper execution schedule.
+```
+
 ## Usage:
 
 If we have the right configuration, we can start the program using the following command - It will read the configuration, start checking if there are pending packages that aren't in the registry and send them to the server that is listening using `beats`- e.g. a logstash instance with the `beats` module -:

--- a/beatshipper-conf.yml
+++ b/beatshipper-conf.yml
@@ -7,6 +7,4 @@ path:
   - "/jenkinst-test/jenkins-logs/rcj/*/*/*/var/log/extra2/rpm-list.txt.gz"
 # the name of the file where we'll store the processed files.
 registry: "shipper_registry.json"
-# time of recheck (re-process) if there are new pending files to send
-recheck: 5s
 log_source: 'gzip_files'

--- a/beatshipper-conf.yml
+++ b/beatshipper-conf.yml
@@ -2,7 +2,7 @@
 host: "localhost"
 port: "5044"
 # array of paths that will be exploded using `GLOB`
-path:
+paths:
   - "/jenkinst-test/jenkins-logs/rcj/*/*/*/var/log/extra/rpm-list.txt.gz"
   - "/jenkinst-test/jenkins-logs/rcj/*/*/*/var/log/extra2/rpm-list.txt.gz"
 # the name of the file where we'll store the processed files.

--- a/beatshipper-conf.yml
+++ b/beatshipper-conf.yml
@@ -7,4 +7,4 @@ paths:
   - "/jenkinst-test/jenkins-logs/rcj/*/*/*/var/log/extra2/rpm-list.txt.gz"
 # the name of the file where we'll store the processed files.
 registry: "shipper_registry.json"
-log_source: 'gzip_files'
+logsource: 'gzip_files'

--- a/configs/config.go
+++ b/configs/config.go
@@ -3,7 +3,6 @@ package configs
 import (
 	"log"
 	"os"
-	"time"
 
 	"github.com/spf13/viper"
 )
@@ -13,7 +12,6 @@ type Configuration struct {
 	Port      string   `yaml:"port"`
 	Paths     []string `yaml:"path"`
 	Registry  string   `yaml:"registry"`
-	Recheck   string   `yaml:"recheck"`
 	LogSource string   `yaml:"logsource"`
 }
 
@@ -21,12 +19,15 @@ func (c *Configuration) GetConfiguration() *Configuration {
 	userDirConfig, err := os.UserConfigDir()
 
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
+	}
+
+	if len(userDirConfig) > 0 {
+		viper.AddConfigPath(userDirConfig)
 	}
 
 	viper.SetConfigName("beatshipper-conf")
 	viper.AddConfigPath("/etc/beatshipper/")
-	viper.AddConfigPath(userDirConfig)
 
 	err = viper.ReadInConfig()
 
@@ -41,21 +42,4 @@ func (c *Configuration) GetConfiguration() *Configuration {
 	}
 
 	return c
-}
-
-func (c *Configuration) GetRecheckInSeconds() int32 {
-	t, err := time.ParseDuration(c.Recheck)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	s := t.Seconds()
-	return int32(s)
-}
-
-func (c *Configuration) GetRecheckDuration() time.Duration {
-	recheckSeconds := c.GetRecheckInSeconds()
-	recheckDuration := time.Second * time.Duration(recheckSeconds)
-	return recheckDuration
 }

--- a/configs/config.go
+++ b/configs/config.go
@@ -3,6 +3,7 @@ package configs
 import (
 	"log"
 	"os"
+	"reflect"
 
 	"github.com/spf13/viper"
 )
@@ -41,5 +42,19 @@ func (c *Configuration) GetConfiguration() *Configuration {
 		log.Fatal(err)
 	}
 
+	checkConfigurationFields(*c)
+
 	return c
+}
+
+// Check if all the fields of the configuration struct have value
+// Check if the field key of the configuration exist
+func checkConfigurationFields(c Configuration) {
+	structFields := reflect.ValueOf(c)
+
+	for i := 0; i < structFields.NumField(); i++ {
+		if structFields.Field(i).IsZero() {
+			log.Fatalf("%s field of struct empty.", structFields.Type().Field(i).Name)
+		}
+	}
 }

--- a/lib/systemd/system/beatshipper.service
+++ b/lib/systemd/system/beatshipper.service
@@ -4,14 +4,10 @@ Documentation=https://github.com/RedHatCRE/beatshipper/blob/main/README.md
 After=network.target
 
 [Service]
+# Working with timers:
+Type=oneshot
 WorkingDirectory=/etc/beatshipper
-Type=simple
-ExecStart=/usr/sbin/beatshipper
-Restart=on-failure
-RestartSec=10
-# TODO: Do we want to keep the logs in syslog?
-StandardOutput=syslog
-StandardError=syslog
+ExecStart=/usr/sbin/beatshipper send
 SyslogIdentifier=beatshipper
 [Install]
 WantedBy=multi-user.target

--- a/lib/systemd/system/beatshipper.timer
+++ b/lib/systemd/system/beatshipper.timer
@@ -1,0 +1,15 @@
+[Unit]
+Description=Beatshipper execution schedule
+# Allow manual start/stop
+RefuseManualStart=no
+RefuseManualStop=no
+
+[Timer]
+Persistent=true
+OnBootSec=120
+# Every 30 minutes
+OnCalendar=*:0/30
+Unit=beatshipper.service 
+
+[Install]
+WantedBy=timers.target

--- a/packing_manager_specs/RPM/rpmbuild/SPECS/beatshipper.spec
+++ b/packing_manager_specs/RPM/rpmbuild/SPECS/beatshipper.spec
@@ -25,7 +25,7 @@ install -m 0755 -d %{buildroot}/lib/systemd/system/
 # Copy files with right permissions:
 install -m 0755 %{_rpmdir}%{name} %{buildroot}/usr/sbin/%{name}
 install -m 0644 %{_rpmdir}/beatshipper-conf.yml %{buildroot}/etc/%{name}/
-install -m 0644 %{_rpmdir}/lib/systemd/system/beatshipper.service %{buildroot}/lib/systemd/system/
+install -m 0644 %{_rpmdir}/lib/systemd/system/* %{buildroot}/lib/systemd/system/
 
 %post
 
@@ -35,7 +35,7 @@ rm -rf $RPM_BUILD_ROOT
 %files
 /usr/sbin/%{name}
 /etc/%{name}/beatshipper-conf.yml
-/lib/systemd/system/beatshipper.service
+/lib/systemd/system/
 
 %changelog
  # END SPEC


### PR DESCRIPTION
In the end I'll keep beatshipper simple.

- I've added a timer file and modified the systemd service. The service will be now with oneshot type and linked to the timer that will launch it every 30 minutes.
- I've deleted the recheck option in all the app. It won't be required since I won't use server mode.
- I've modified the spec file to also copy the timer file to the corresponding folder.
- I've changed the way viper gets the User configuration. In case the app is called by the service it won't have a HOME defined. It can be fixed using a user for beatshipper. I can check this in another PR.
- Add func to check the configuration struct fields aren't empty.